### PR TITLE
Fixed node count for disabled workers

### DIFF
--- a/check_jk_status.pl
+++ b/check_jk_status.pl
@@ -186,7 +186,12 @@ sub ParseXML
       my $activation = $status->{'jk:balancers'}->{'jk:balancer'}->{$options->balancer}->{'jk:member'}->{$member}->{'activation'};
       my $state = $status->{'jk:balancers'}->{'jk:balancer'}->{$options->balancer}->{'jk:member'}->{$member}->{'state'};
 
-      if ( $activation ne 'ACT' )
+      # if a node is in diisable status, skip the other checks
+      # nodes marked as failover are in disable status
+      if ( $activation eq 'DIS' )
+      {
+         $member_count = $member_count - 1;
+      } elsif ( $activation ne 'ACT' )
       {
          push (@bad_members, $member);
       } elsif ( $activation eq 'ACT' ) {


### PR DESCRIPTION
When using Active/Standby nodes, the standby nodes are set in disabled (DIS) state.
This would count any standby node as "not working".

The patch aim to skip the count for the standby nodes.
Something better can be done of course, like adding a parameter that say how many nodes are disabled.